### PR TITLE
[RFC] Port from Python 2.7.x to 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A major use-case for this tool is to visualize Abstract Syntax Trees (ASTs) that
 
 ### Requirements
 
-You need Python 2.7.x, PyYAML, and GraphViz installed:
+You need Python 3.x, PyYAML, and GraphViz installed:
 
 ```
 sudo pip install pyyaml

--- a/show.py
+++ b/show.py
@@ -2,7 +2,6 @@
 
 import sys
 import yaml
-import string
 
 
 def out (s):
@@ -17,7 +16,7 @@ def getID():
     return n
 
 def asAttr(attr, val):
-    escaped = string.replace(val, '\"', '\\\"')  # " -> \"
+    escaped = val.replace('\"', '\\\"')  # " -> \"
     return " [" + attr + "=\"" + escaped + "\"]"
 
 def render(ast, name=None):
@@ -28,7 +27,7 @@ def render(ast, name=None):
     edges = []  # (from, to, attr)
 
     if type(ast) is dict:
-        for key,val in ast.iteritems():
+        for key,val in ast.items():
 
             if type(val) is dict:
                 child = getID()
@@ -67,15 +66,15 @@ def render(ast, name=None):
 # check args
 myself = sys.argv[0]
 if len(sys.argv) != 2:
-    print "error: invalid number of arguments."
-    print "usage:\t" + myself + " [path to YAML file]"
+    print("error: invalid number of arguments.")
+    print("usage:\t" + myself + " [path to YAML file]")
     sys.exit(1)
 
 infile = sys.argv[1]
 
 with open(infile, 'r') as stream:
     try:
-        ast = yaml.load(stream)
+        ast = yaml.load(stream, Loader=yaml.CLoader)
 
         out ("digraph graphname {\n")
 


### PR DESCRIPTION
I came across this script and wanted to give it a try.
Instead of installing a deprecated Python version, I went ahead and adjusted the script to work under a modern setup.

This is what I have done:

* Python 2 `string.replace()` -> Python 3 `str.replace()`
* Python 2 `dict.iteritems()` -> Python 3 `dict.items()`
* Python 2 `print` -> Python 3 `print()`
* pre-5.1+ `yaml.load()` -> 5.1+ `yaml.load(Loader=)`

It appears to be working just fine so I figured I share it back.

Let me know if you are interested in merging this and what else you'd like me to do or if you'd prefer me to maintain my own fork (and potentially package it for distributions I use).

At least this can serve as a reference for others that want to use yaml-ast on system without Python 2.7.x support.

---
Note: To maintain backwards compatibility (regarding YAML input, not Python 2.7.x), is opted for the (unsafe) default `Loader`.
If you are interested in including this, I think we should add a command line flag to support safer options and maybe even issue a warning to stderr when run with default parameters.
But before thinking this through in detail, I figured I'd first put out what I have and see if there is and interest in this at all.